### PR TITLE
Add auth login and bearer token support to Postman workspace

### DIFF
--- a/postman/README.md
+++ b/postman/README.md
@@ -37,6 +37,25 @@ Once imported and selected, the requests will work without needing to manually e
 | cartId       | 1                         |
 | rating       | 5                         |
 | comment      | Great game!               |
+| token        | (auto-generated)          |
+
+---
+
+## Authentication
+
+Some endpoints require authentication using a bearer token.
+
+### Steps:
+
+1. Open the **Auth → Login** request in the collection
+2. Click **Send**
+3. The token will be automatically stored in the environment
+4. All other requests will automatically use the token via: Authorization: Bearer {{token}}
+
+
+### Notes:
+- The token is automatically captured from the login response
+- If the token expires, re-run the login request to refresh it
 
 ---
 
@@ -44,7 +63,6 @@ Once imported and selected, the requests will work without needing to manually e
 
 - The backend server must be running before sending requests.
 - Default base URL assumes local development: http://localhost:8080
-
 - Some endpoints depend on existing data (e.g., gameId, userId), so certain requests may require creating records first.
 
 ---
@@ -53,6 +71,7 @@ Once imported and selected, the requests will work without needing to manually e
 
 The collection includes endpoints for:
 
+- Authentication (Login)
 - Video Games
 - User Profiles
 - User Types

--- a/postman/SFWE_405_Local_Variables.postman_environment.json
+++ b/postman/SFWE_405_Local_Variables.postman_environment.json
@@ -4,61 +4,67 @@
 	"values": [
 		{
 			"key": "baseUrl",
-			"value": "http://localhost:8080",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "api",
-			"value": "/api",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "id",
-			"value": "1",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "developerId",
-			"value": "1",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "gameId",
-			"value": "1",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "userId",
-			"value": "1",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "cartId",
-			"value": "1",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "rating",
-			"value": "5",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "comment",
-			"value": "Great game!",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"color": 300,
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2026-03-30T15:24:14.658Z",
+	"_postman_exported_at": "2026-03-31T02:41:38.237Z",
 	"_postman_exported_using": "Postman/12.4.0"
 }

--- a/postman/SFWE_405_api_testing.postman_collection.json
+++ b/postman/SFWE_405_api_testing.postman_collection.json
@@ -1065,8 +1065,64 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const response = pm.response.json();\r",
+                  "pm.environment.set(\"token\", response.token);"
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"username\": \"testuser\",\r\n  \"password\": \"password\"\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}{{api}}/auth/login",
+              "host": [
+                "{{baseUrl}}{{api}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{token}}",
+        "type": "string"
+      }
+    ]
+  },
   "event": [
     {
       "listen": "prerequest",
@@ -1126,8 +1182,7 @@
     },
     {
       "key": "comment",
-      "value": "",
-      "type": "default"
+      "value": ""
     }
   ]
 }


### PR DESCRIPTION
Updated the Postman workspace to support authentication.

Added:
- auth/login endpoint
- automatic token capture from the login response
- bearer token authorization using the environment token variable
- updated README with authentication instructions
