### PR TITLE
Add Gatling simulation and update pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,68 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.10</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>gaming-platform</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>gaming-platform</name>
-	<description>SFWE 405/505 Semester Project</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>25</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.10</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>gaming-platform</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>gaming-platform</name>
+    <description>SFWE 405/505 Semester Project</description>
+    <properties>
+        <java.version>21</java.version>
+        <!-- Gatling -->
+        <gatling.version>3.13.5</gatling.version>
+        <gatling-maven-plugin.version>4.10.2</gatling-maven-plugin.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <!-- Gatling dependencies -->
+        <dependency>
+            <groupId>io.gatling.highcharts</groupId>
+            <artifactId>gatling-charts-highcharts</artifactId>
+            <version>${gatling.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling</groupId>
+            <artifactId>gatling-core-java</artifactId>
+            <version>${gatling.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket</artifactId>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
+            <!-- Gatling Maven Plugin -->
+            <plugin>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-maven-plugin</artifactId>
+                <version>${gatling-maven-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/simulations/MySimulation.java
+++ b/src/test/java/simulations/MySimulation.java
@@ -1,0 +1,127 @@
+package simulations;
+
+import io.gatling.javaapi.core.*;
+import io.gatling.javaapi.http.*;
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+public class MySimulation extends Simulation {
+
+    HttpProtocolBuilder httpProtocol = http
+        .baseUrl("http://localhost:8080")
+        .acceptHeader("application/json")
+        .contentTypeHeader("application/json");
+
+    // --- Scenario: Video Games ---
+    ScenarioBuilder videoGames = scenario("Video Games")
+        .exec(
+            http("Get All Video Games")
+                .get("/api/video-games")
+                .check(status().is(200))
+        )
+        .pause(1)
+        .exec(
+            http("Create Video Game")
+                .post("/api/video-games")
+                .body(StringBody("""
+                    {
+                      "name": "Halo Infinite",
+                      "releaseDate": "2026-02-17T00:00:00.000+00:00",
+                      "category": "ACTION",
+                      "system": "XBOX"
+                    }
+                """)).asJson()
+                .check(status().is(200))
+        );
+
+    // --- Scenario: User Profiles ---
+    ScenarioBuilder userProfiles = scenario("User Profiles")
+        .exec(
+            http("Get All User Profiles")
+                .get("/api/user-profiles")
+                .check(status().is(200))
+        )
+        .pause(1)
+        .exec(
+            http("Create User Profile")
+                .post("/api/user-profiles")
+                .body(StringBody("""
+                    {
+                      "email": "renae@example.com",
+                      "userName": "Gamer1",
+                      "status": "ACTIVE",
+                      "preferredCategories": ["RPG", "INDIE"],
+                      "gameLibrary": []
+                    }
+                """)).asJson()
+                .check(status().is(200))
+        );
+
+    // --- Scenario: Orders ---
+    ScenarioBuilder orders = scenario("Orders")
+        .exec(
+            http("Get All Orders")
+                .get("/api/orders")
+                .check(status().is(200))
+        )
+        .pause(1)
+        .exec(
+            http("Create Order")
+                .post("/api/orders")
+                .body(StringBody("""
+                    {
+                      "orderDate": "2026-03-24T12:00:00",
+                      "totalAmount": 59.99
+                    }
+                """)).asJson()
+                .check(status().is(200))
+        );
+
+    // --- Scenario: Developers ---
+    ScenarioBuilder developers = scenario("Developers")
+        .exec(
+            http("Get All Developers")
+                .get("/api/developers")
+                .check(status().is(200))
+        )
+        .pause(1)
+        .exec(
+            http("Create Developer")
+                .post("/api/developers")
+                .body(StringBody("""
+                    {
+                      "name": "Nintendo"
+                    }
+                """)).asJson()
+                .check(status().is(200))
+        );
+
+    // --- Scenario: Webstore ---
+    ScenarioBuilder webstore = scenario("Webstore")
+        .exec(
+            http("Get All Webstores")
+                .get("/api/webstore")
+                .check(status().is(200))
+        )
+        .pause(1)
+        .exec(
+            http("Create Webstore")
+                .post("/api/webstore")
+                .body(StringBody("""
+                    {
+                      "name": "Main Store"
+                    }
+                """)).asJson()
+                .check(status().is(200))
+        );
+
+    {
+        setUp(
+            videoGames.injectOpen(rampUsers(10).during(10)),
+            userProfiles.injectOpen(rampUsers(10).during(10)),
+            orders.injectOpen(rampUsers(10).during(10)),
+            developers.injectOpen(rampUsers(10).during(10)),
+            webstore.injectOpen(rampUsers(10).during(10))
+        ).protocols(httpProtocol);
+    }
+}


### PR DESCRIPTION
Enable Gatling-based performance tests and adjust project config: update pom formatting and java.version (21), add Gatling properties, test dependencies (gatling-charts-highcharts, gatling-core-java) and gatling-maven-plugin. Keep existing Spring Boot, H2, and websocket dependencies. Add a new Gatling simulation test src/test/java/simulations/MySimulation.java that defines scenarios for Video Games, User Profiles, Orders, Developers and Webstore, each performing basic GET/POST flows and ramping 10 users over 10s.