### PR TITLE
Add chat UI/WebSocket client; fix chat room race

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom'
 import Home from './Home.jsx'
 import Login from './Login.jsx'
 import Signup from './Signup.jsx'
+import ChatPage from './ChatPage.jsx'
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Signup />} />
+      <Route path="/chat" element={<ChatPage />} />
     </Routes>
   )
 }

--- a/frontend/src/ChatList.css
+++ b/frontend/src/ChatList.css
@@ -1,0 +1,36 @@
+.chat-list {
+  width: 220px; background: #16213e;
+  border-right: 1px solid rgba(255,255,255,0.07);
+  display: flex; flex-direction: column;
+  font-family: "Segoe UI", sans-serif;
+}
+.chat-list-header {
+  padding: 18px 16px 12px; font-size: 13px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: #888;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.chat-list-items { flex: 1; overflow-y: auto; padding: 8px 0; }
+.chat-list-empty { color: #555; font-size: 13px; text-align: center; padding: 24px 16px; }
+.chat-list-item {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 10px 14px; background: none; border: none;
+  cursor: pointer; text-align: left; color: #b0b0d0; transition: background 0.15s;
+}
+.chat-list-item:hover { background: rgba(108,99,255,0.1); }
+.chat-list-item.active { background: rgba(108,99,255,0.18); color: #fff; }
+.chat-list-avatar {
+  width: 34px; height: 34px; border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #48cae4);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700; color: #fff; font-size: 13px;
+  overflow: hidden; flex-shrink: 0;
+}
+.chat-list-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.chat-list-name {
+  flex: 1; font-size: 14px; font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.chat-list-badge {
+  background: #6c63ff; color: #fff; font-size: 11px; font-weight: 700;
+  border-radius: 999px; padding: 2px 7px; min-width: 20px; text-align: center;
+}

--- a/frontend/src/ChatList.jsx
+++ b/frontend/src/ChatList.jsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import "./ChatList.css";
+
+export default function ChatList({ currentUserId, users = [], onSelectUser, activeUserId }) {
+  const [unreadCounts, setUnreadCounts] = useState({});
+
+  useEffect(() => {
+    if (!currentUserId || users.length === 0) return;
+    const fetchUnread = async () => {
+      const counts = {};
+      await Promise.all(users.map(async (user) => {
+        try {
+          const res = await fetch(`/api/messages/${user.id}/${currentUserId}/count`);
+          if (res.ok) counts[user.id] = await res.json();
+        } catch { counts[user.id] = 0; }
+      }));
+      setUnreadCounts(counts);
+    };
+    fetchUnread();
+    const interval = setInterval(fetchUnread, 10_000);
+    return () => clearInterval(interval);
+  }, [currentUserId, users]);
+
+  return (
+    <div className="chat-list">
+      <div className="chat-list-header">Messages</div>
+      <div className="chat-list-items">
+        {users.length === 0 && (
+          <div className="chat-list-empty">No players found.</div>
+        )}
+        {users.map((user) => (
+          <button
+            key={user.id}
+            className={`chat-list-item ${activeUserId === user.id ? "active" : ""}`}
+            onClick={() => onSelectUser(user)}
+          >
+            <div className="chat-list-avatar">
+              {user.avatarUrl
+                ? <img src={user.avatarUrl} alt={user.username} />
+                : <span>{user.username?.[0]?.toUpperCase()}</span>}
+            </div>
+            <span className="chat-list-name">{user.username}</span>
+            {unreadCounts[user.id] > 0 && (
+              <span className="chat-list-badge">{unreadCounts[user.id]}</span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ChatPage.jsx
+++ b/frontend/src/ChatPage.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import ChatList from "./ChatList.jsx";
+import ChatWindow from "./ChatWindow.jsx";
+
+const CURRENT_USER = { id: "user_alice", username: "Alice" };
+
+const MOCK_USERS = [
+  { id: "user_bob", username: "Bob" },
+  { id: "user_charlie", username: "Charlie" },
+];
+
+export default function ChatPage() {
+  const [selectedUser, setSelectedUser] = useState(null);
+
+  return (
+    <div style={{ display: "flex", height: "100vh", background: "#0f0f23" }}>
+      <ChatList
+        currentUserId={CURRENT_USER.id}
+        users={MOCK_USERS}
+        activeUserId={selectedUser?.id}
+        onSelectUser={setSelectedUser}
+      />
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        {selectedUser ? (
+          <ChatWindow
+            currentUserId={CURRENT_USER.id}
+            recipient={selectedUser}
+            onClose={() => setSelectedUser(null)}
+          />
+        ) : (
+          <p style={{ color: "#555", fontFamily: "sans-serif" }}>
+            Select a player to start chatting
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ChatWindow.css
+++ b/frontend/src/ChatWindow.css
@@ -1,0 +1,73 @@
+.chat-window {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 520px;
+  background: #1a1a2e;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  font-family: "Segoe UI", sans-serif;
+  border: 1px solid rgba(255,255,255,0.08);
+}
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: #16213e;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.chat-header-info { display: flex; align-items: center; gap: 10px; }
+.chat-avatar {
+  width: 38px; height: 38px; border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #48cae4);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700; color: #fff; font-size: 15px;
+  overflow: hidden; flex-shrink: 0;
+}
+.chat-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.chat-username { font-weight: 600; color: #e0e0f0; font-size: 14px; }
+.chat-status { font-size: 11px; margin-top: 2px; }
+.chat-status.online { color: #4cff91; }
+.chat-status.offline { color: #888; }
+.chat-close-btn {
+  background: none; border: none; color: #888;
+  font-size: 16px; cursor: pointer; padding: 4px 8px;
+  border-radius: 6px; transition: background 0.2s, color 0.2s;
+}
+.chat-close-btn:hover { background: rgba(255,255,255,0.08); color: #fff; }
+.chat-messages {
+  flex: 1; overflow-y: auto; padding: 16px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.chat-empty { text-align: center; color: #555; font-size: 13px; margin: auto; }
+.chat-bubble-wrapper { display: flex; }
+.chat-bubble-wrapper.mine { justify-content: flex-end; }
+.chat-bubble-wrapper.theirs { justify-content: flex-start; }
+.chat-bubble {
+  max-width: 72%; padding: 9px 13px; border-radius: 16px;
+  font-size: 14px; line-height: 1.45;
+  display: flex; flex-direction: column; gap: 4px; word-break: break-word;
+}
+.chat-bubble.mine {
+  background: linear-gradient(135deg, #6c63ff, #48cae4);
+  color: #fff; border-bottom-right-radius: 4px;
+}
+.chat-bubble.theirs {
+  background: #2a2a4a; color: #d0d0e8; border-bottom-left-radius: 4px;
+}
+.chat-bubble-meta { font-size: 10px; opacity: 0.65; align-self: flex-end; }
+.chat-input-area {
+  display: flex; align-items: flex-end; gap: 8px;
+  padding: 12px 14px; background: #16213e;
+  border-top: 1px solid rgba(255,255,255,0.07);
+}
+.chat-input {
+  flex: 1; background: #0f0f23;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px; padding: 10px 14px;
+  color: #e0e0f0; font-size: 14px; resize: none;
+  outline: none; font-family: inherit; transition: border-color 0.2s;
+}
+.chat-input:focus { border-color: #6c63ff; }

--- a/frontend/src/ChatWindow.jsx
+++ b/frontend/src/ChatWindow.jsx
@@ -1,0 +1,91 @@
+import { useState, useEffect, useRef } from "react";
+import { useChat } from "./hooks/useChat";
+import "./ChatWindow.css";
+
+export default function ChatWindow({ currentUserId, recipient, onClose }) {
+  const [inputValue, setInputValue] = useState("");
+  const bottomRef = useRef(null);
+  const { messages, sendMessage, connected } = useChat(currentUserId, recipient.id);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = () => {
+    if (!inputValue.trim()) return;
+    sendMessage(inputValue);
+    setInputValue("");
+  };
+
+  const formatTime = (ts) =>
+    ts ? new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
+
+  return (
+    <div className="chat-window">
+      <div className="chat-header">
+        <div className="chat-header-info">
+          <div className="chat-avatar">
+            {recipient.avatarUrl
+              ? <img src={recipient.avatarUrl} alt={recipient.username} />
+              : <span>{recipient.username?.[0]?.toUpperCase()}</span>}
+          </div>
+          <div>
+            <div className="chat-username">{recipient.username}</div>
+            <div className={`chat-status ${connected ? "online" : "offline"}`}>
+              {connected ? "Online" : "Connecting..."}
+            </div>
+          </div>
+        </div>
+        <button className="chat-close-btn" onClick={onClose}>✕</button>
+      </div>
+
+      <div className="chat-messages">
+        {messages.length === 0 && (
+          <div className="chat-empty">No messages yet. Say hello!</div>
+        )}
+        {messages.map((msg, idx) => {
+          const isMine = msg.senderId === currentUserId;
+          return (
+            <div key={msg.id || idx} className={`chat-bubble-wrapper ${isMine ? "mine" : "theirs"}`}>
+              <div className={`chat-bubble ${isMine ? "mine" : "theirs"}`}>
+                <span className="chat-bubble-text">{msg.content}</span>
+                <span className="chat-bubble-meta">
+                  {formatTime(msg.timestamp)}
+                  {isMine && (
+                    <span className="chat-status-icon">
+                      {msg.status === "DELIVERED" || msg.status === "READ" ? " ✓✓" : " ✓"}
+                    </span>
+                  )}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="chat-input-area">
+        <textarea
+          className="chat-input"
+          rows={1}
+          placeholder="Type a message..."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+        />
+        <button
+          className="chat-send-btn"
+          onClick={handleSend}
+          disabled={!inputValue.trim() || !connected}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChat.js
+++ b/frontend/src/hooks/useChat.js
@@ -1,0 +1,52 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+
+const SOCKET_URL = "http://localhost:8080/ws";
+
+export function useChat(currentUserId, recipientId) {
+  const [messages, setMessages] = useState([]);
+  const [connected, setConnected] = useState(false);
+  const clientRef = useRef(null);
+
+  useEffect(() => {
+    if (!currentUserId || !recipientId) return;
+    fetch(`/api/messages/${currentUserId}/${recipientId}`)
+      .then((res) => res.json())
+      .then(setMessages)
+      .catch(console.error);
+  }, [currentUserId, recipientId]);
+
+  useEffect(() => {
+    if (!currentUserId) return;
+    const client = new Client({
+      webSocketFactory: () => new SockJS(SOCKET_URL),
+      reconnectDelay: 5000,
+      onConnect: () => {
+        setConnected(true);
+        client.subscribe(`/user/${currentUserId}/queue/messages`, (msg) => {
+          setMessages((prev) => [...prev, JSON.parse(msg.body)]);
+        });
+      },
+      onDisconnect: () => setConnected(false),
+    });
+    client.activate();
+    clientRef.current = client;
+    return () => client.deactivate();
+  }, [currentUserId]);
+
+  const sendMessage = useCallback((content) => {
+    if (!clientRef.current?.connected || !content.trim()) return;
+    const message = { senderId: currentUserId, recipientId, content: content.trim() };
+    setMessages((prev) => [
+      ...prev,
+      { ...message, timestamp: new Date().toISOString(), status: "SENT" },
+    ]);
+    clientRef.current.publish({
+      destination: "/app/chat",
+      body: JSON.stringify(message),
+    });
+  }, [currentUserId, recipientId]);
+
+  return { messages, sendMessage, connected };
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,3 +1,5 @@
+window.global = window;
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    global: 'globalThis',
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+      '/ws': 'http://localhost:8080',
+    }
+  }
 })

--- a/src/main/java/com/example/gaming_platform/controller/ChatController.java
+++ b/src/main/java/com/example/gaming_platform/controller/ChatController.java
@@ -33,6 +33,7 @@ public class ChatController {
  * Processes message.
  *
  * @param chatMessage the chat message
+ *  This method is weboscket pushing a reveciving in real time
  */
     @MessageMapping("/chat")
     public void processMessage(@Payload ChatMessage chatMessage) {

--- a/src/main/java/com/example/gaming_platform/service/ChatRoomService.java
+++ b/src/main/java/com/example/gaming_platform/service/ChatRoomService.java
@@ -3,33 +3,21 @@ package com.example.gaming_platform.service;
 import com.example.gaming_platform.entity.ChatRoom;
 import com.example.gaming_platform.repository.ChatRoomRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
-/**
- * Service for chat room business operations.
- */
 @Service
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
 
-/**
- * Creates a new ChatRoomService instance.
- *
- * @param chatRoomRepository the chat room repository
- */
     public ChatRoomService(ChatRoomRepository chatRoomRepository) {
         this.chatRoomRepository = chatRoomRepository;
     }
 
-/**
- * Gets the or create chat room ID.
- *
- * @param senderId the sender ID
- * @param recipientId the recipient ID
- * @return the or create chat room ID
- */
+    @Transactional
     public String getOrCreateChatRoomId(String senderId, String recipientId) {
+        // Check both directions first
         Optional<ChatRoom> existing = chatRoomRepository
                 .findBySenderIdAndRecipientId(senderId, recipientId);
         if (existing.isPresent()) return existing.get().getChatRoomId();
@@ -38,8 +26,18 @@ public class ChatRoomService {
                 .findBySenderIdAndRecipientId(recipientId, senderId);
         if (reverse.isPresent()) return reverse.get().getChatRoomId();
 
-        String chatRoomId = senderId + "_" + recipientId;
-        chatRoomRepository.save(new ChatRoom(chatRoomId, senderId, recipientId));
-        return chatRoomId;
+        // Try to create, catch duplicate if another request beat us to it
+        try {
+            String chatRoomId = senderId + "_" + recipientId;
+            chatRoomRepository.save(new ChatRoom(chatRoomId, senderId, recipientId));
+            return chatRoomId;
+        } catch (Exception e) {
+            // Another request already created it, just look it up
+            return chatRoomRepository
+                    .findBySenderIdAndRecipientId(senderId, recipientId)
+                    .or(() -> chatRoomRepository.findBySenderIdAndRecipientId(recipientId, senderId))
+                    .map(ChatRoom::getChatRoomId)
+                    .orElseThrow(() -> new RuntimeException("Could not find or create chat room"));
+        }
     }
 }


### PR DESCRIPTION
Introduce a realtime chat feature: add ChatPage, ChatList, ChatWindow components and corresponding CSS; register /chat route in App. Implement useChat hook using STOMP + SockJS to fetch history, subscribe to /user/{id}/queue/messages, send messages and expose connection state. Add periodic unread count fetch in ChatList and auto-scroll/send behavior in ChatWindow. Add window.global polyfill and update Vite config to define globalThis and proxy /api and /ws to backend. On the backend, make ChatRoomService.getOrCreateChatRoomId transactional and resilient to concurrent creation (catch/lookup fallback) to avoid duplicate chat rooms; also a small Javadoc note added to ChatController.